### PR TITLE
feat: Make the cluster amd64 as well as arm64

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ module "eks" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_architecture"></a> [architecture](#input\_architecture) | The architecture to use for the EKS cluster | `string` | `"arm64"` | no |
 | <a name="input_cidr_block"></a> [cidr\_block](#input\_cidr\_block) | CIDR block for the VPC - if we are creating a new VPC | `string` | n/a | yes |
 | <a name="input_common_tags"></a> [common\_tags](#input\_common\_tags) | Common tags to apply to all resources | `map(string)` | n/a | yes |
 | <a name="input_create_vpc"></a> [create\_vpc](#input\_create\_vpc) | Whether to create a new VPC or use an existing one | `bool` | `true` | no |

--- a/eks.tf
+++ b/eks.tf
@@ -90,7 +90,7 @@ resource "aws_eks_addon" "pod_identity" {
 resource "aws_launch_template" "eks_managed" {
   name_prefix   = "${local.project_id}-eks-ng-"
   image_id      = null # Let EKS manage the AMI unless you have a custom one
-  instance_type = "t4g.medium"
+  instance_type = "${local.machine_type}.medium"
 
   metadata_options {
     http_tokens = "required"
@@ -132,7 +132,7 @@ resource "aws_eks_node_group" "managed" {
     version = "$Latest"
   }
 
-  ami_type      = "AL2023_ARM_64_STANDARD"
+  ami_type      = var.architecture == "arm64" ? "AL2023_ARM_64_STANDARD" : "AL2023_x86_64_STANDARD"
   capacity_type = "SPOT"
 
   tags = merge(local.common_tags, { Name = "${local.project_id}-managed-nodes" })
@@ -354,10 +354,10 @@ spec:
       requirements:
         - key: "node.kubernetes.io/instance-type"
           operator: In
-          values: ["t4g.small", "t4g.medium", "t4g.large"]
+          values: ["${local.machine_type}.small", "${local.machine_type}.medium", "${local.machine_type}.large"]
         - key: "kubernetes.io/arch"
           operator: In
-          values: ["arm64"]
+          values: ["${var.architecture}"]
   limits:
     cpu: 1000
   disruption:

--- a/main.tf
+++ b/main.tf
@@ -20,6 +20,9 @@ locals {
     karpenter_role_name = aws_iam_role.karpenter.name
     nodes_role_name     = aws_iam_role.nodes.name
   })
+
+  machine_type = var.architecture == "arm64" ? "t4g" : "t3"
+
 }
 
 module "vpc" {
@@ -36,5 +39,4 @@ module "vpclookup" {
   source = "./modules/vpclookup"
 
   vpc_id = local.vpc_id
-  #cidr_block  = local.cidr_block
 }

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -5,6 +5,9 @@ shortname    = "chrisfu"
 region       = "eu-west-1"
 cidr_block   = "10.3.0.0/16"
 
+# arm64 or amd64
+architecture = "arm64"
+
 common_tags = {
   Environment = "Temporary Lab: eks-lab-chrisfu"
   ManagedBy   = "Terraform"

--- a/variables.tf
+++ b/variables.tf
@@ -28,3 +28,8 @@ variable "create_vpc" {
   description = "Whether to create a new VPC or use an existing one"
   default     = true
 }
+variable "architecture" {
+  type        = string
+  description = "The architecture to use for the EKS cluster"
+  default     = "arm64"
+}


### PR DESCRIPTION
I'm only interested in ARM clusters running on Graviton, but, I suppose it should be able to build on Intel architecture too.  This should do it.

Signed-off-by: Chris Funderburg <c.funderburg@mak-system.net>

Issue: #7