### PR TITLE
fix: Small tweaks to placement and sizing

### DIFF
--- a/eks.tf
+++ b/eks.tf
@@ -354,7 +354,7 @@ spec:
       requirements:
         - key: "node.kubernetes.io/instance-type"
           operator: In
-          values: ["${local.machine_type}.small", "${local.machine_type}.medium", "${local.machine_type}.large"]
+          values: ["${local.machine_type}.micro", "${local.machine_type}.small", "${local.machine_type}.medium", "${local.machine_type}.large"]
         - key: "kubernetes.io/arch"
           operator: In
           values: ["${var.architecture}"]

--- a/karpenter_values.yaml
+++ b/karpenter_values.yaml
@@ -2,6 +2,9 @@ serviceAccount:
   annotations:
     eks.amazonaws.com/role-arn: "${role_arn}"
 
+nodeSelector:
+  karpenter.sh/controller: 'true'
+
 settings:
   clusterName: "${cluster_name}"
   clusterEndpoint: "${cluster_endpoint}"


### PR DESCRIPTION
I can use much smaller nodes - so that's cheaper.

Also, I was missing a nodeselector to ensure karpenter only runs on nodes not controlled with karpenter.